### PR TITLE
Add URL Attachment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.gitignore
 .DS_Store
+.vscode/launch.json
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -210,13 +210,16 @@ will create a card on your board on the list **Today** with the title "make dinn
 The due date will be set as 12/24/2019.  
 The URL `https://myfavoriterestaurant.com` is added as an attachment.
 
-**SCREENSHOTS PENDING**
+![](https://user-images.githubusercontent.com/7596032/71087131-68196980-2169-11ea-85b1-5d1658e00db3.png)
 
+![](https://user-images.githubusercontent.com/7596032/71087140-7071a480-2169-11ea-92a3-ce553316bcf5.png)
+
+![](https://user-images.githubusercontent.com/7596032/71087148-749dc200-2169-11ea-9031-329183f793c9.png)
 ## Advanced Usage  
 
 You can skip any of the available fields by simply adding **;**  
 
-**{Card Title}; {Card Description}; {Labels}; {Due Date}; {List Name}; {Card Position}**
+**{Card Title}; {Card Description}; {Labels}; {Due Date}; {List Name}; {Card Position}; {URL Attachment}**
 
 For example if I wanted to post a card with Title, Label and a Due date i would use this syntax
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 
 
-# Trello Workflow for Alfred App v.1.6.1 
+# Trello Workflow for Alfred App v.1.6.2
 
 ### Create cards in Trello using Alfred App [https://www.alfredapp.com/](https://www.alfredapp.com/)
 
-### [Download Trello WorkFlow 1.6.1](https://github.com/MikoMagni/Trello-Workflow-for-Alfred/releases/tag/1.6.1)
+### [Download Trello WorkFlow 1.6.2](https://github.com/MikoMagni/Trello-Workflow-for-Alfred/releases/tag/1.6.2)
 
 #### Tested and working with Alfred 4.0.x
 
 ## Install
 
-1. Double click on the "**Trello Workflow for Alfred v.1.6.1**" workflow that you have just downloaded.  
+1. Double click on the "**Trello Workflow for Alfred v.1.6.2**" workflow that you have just downloaded.  
 More info: [https://www.alfredapp.com/help/workflows/](https://www.alfredapp.com/help/workflows/)  
 
     Note: if you have version 1.5 installed, remove it before installing the new version.
@@ -200,6 +200,17 @@ Note: If you don't specify a card position, your new card will automatically be 
 
 ![](https://user-images.githubusercontent.com/2527231/39226985-283cb2bc-4895-11e8-9939-1a4bcdb8525d.png)
 
+**URL Attachment**
+
+```
+trello make dinner reservation; table for 10 people at around 7:30pm; blue; 12/24/2019; Today; top; https://myfavoriterestaurant.com
+```
+
+will create a card on your board on the list **Today** with the title "make dinner reservation" and description "table for 10 people at around 7:30pm" with a "blue" label.
+The due date will be set as 12/24/2019.  
+The URL `https://myfavoriterestaurant.com` is added as an attachment.
+
+**SCREENSHOTS PENDING**
 
 ## Advanced Usage  
 

--- a/Resources/trello.php
+++ b/Resources/trello.php
@@ -10,11 +10,11 @@
                                                                           
                                                                           
 Script: 	   		Trello Workflow for Alfred
-Version:        		1.6.1
+Version:        		1.6.2
 Author: 	    		@mikomagni @tomlongo 
-Contributors:   		@cokeby190 @cheryl @deanishe @gamell 
+Contributors:   		@cokeby190 @cheryl @deanishe @gamell @geojunkie
 Desc:		    		Adds card to Trello
-Updated:	    		16/07/18
+Updated:	    		18/12/19
 Source: 			https://github.com/MikoMagni/Trello-Workflow-for-Alfred
 
 */
@@ -31,6 +31,7 @@ $labels 			= (isset($data[5])) ? stripslashes(trim($data[5])) : (getenv('trello.
 $due 				= (isset($data[6])) ? stripslashes(trim($data[6])) : (getenv('trello.due') ?: '');
 $list_name 			= (isset($data[7])) ? stripslashes(trim($data[7])) : (getenv('trello.list_name') ?: '') ;
 $position 			= (isset($data[8])) ? stripslashes(trim($data[8])) : (getenv('trello.position') ?: 'bottom');
+$url_attachment		= (isset($data[9])) ? stripslashes(trim($data[9])) : '';
 $url 				= "{$trello_api_endpoint}/boards/{$trello_board_id}?lists=open&list_fields=name&fields=name,desc&key={$trello_key}&token={$trello_token}";
 
 $ch 				= curl_init();
@@ -66,7 +67,8 @@ if (@fsockopen('duckduckgo.com', 80)) {
 				'labels' => $labels,
 				'due' => $due,
 				'idList' => $trello_list_id,
-				'pos' => $position
+				'pos' => $position,
+				'urlSource' => $url_attachment
 			)) ,
 		));
 		$result = curl_exec($ch);


### PR DESCRIPTION
Add an URL Attachment option 

I added an extra `{URL Attachment}` option to attach a URL to a card. To avoid having to change existing workflows people may have had in use, it's been added to the end of the list.

I also updated the README file with what I think are the necessary updates.

**URL Attachment**

```
trello make dinner reservation; table for 10 people at around 7:30pm; blue; 12/24/2019; Today; top; https://myfavoriterestaurant.com
```

will create a card on your board on the list **Today** with the title "make dinner reservation" and description "table for 10 people at around 7:30pm" with a "blue" label.
The due date will be set as 12/24/2019.  
The URL `https://myfavoriterestaurant.com` is added as an attachment.

<img width="576" alt="Screen Shot 2019-12-18 at 07 06 03" src="https://user-images.githubusercontent.com/7596032/71087131-68196980-2169-11ea-85b1-5d1658e00db3.png">

<img width="844" alt="Screen Shot 2019-12-18 at 07 25 02" src="https://user-images.githubusercontent.com/7596032/71087140-7071a480-2169-11ea-92a3-ce553316bcf5.png">

<img width="791" alt="Screen Shot 2019-12-18 at 07 25 30" src="https://user-images.githubusercontent.com/7596032/71087148-749dc200-2169-11ea-9031-329183f793c9.png">
